### PR TITLE
Initialize `meas_no_coil` regularization entries to zero

### DIFF
--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -227,7 +227,8 @@ int rtgsfit(
     double rcond = -1.0;
     double xpt_flux_max;
     double single_vals[N_COEF], meas_no_coil_cp[N_MEAS];
-    double source[N_GRID], meas_no_coil[N_MEAS], meas_model[N_MEAS];
+    double source[N_GRID], meas_no_coil[N_MEAS];
+    double meas_no_coil[N_MEAS] = {0};
     double flux_pls[N_GRID], flux_vessel[N_GRID];
     double lcfs_flux, axis_flux, axis_r, axis_z;
     double xpt_r[N_XPT_MAX], xpt_z[N_XPT_MAX], xpt_flux[N_XPT_MAX];

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -227,7 +227,7 @@ int rtgsfit(
     double rcond = -1.0;
     double xpt_flux_max;
     double single_vals[N_COEF], meas_no_coil_cp[N_MEAS];
-    double source[N_GRID], meas_no_coil[N_MEAS];
+    double source[N_GRID], meas_model[N_MEAS];
     double meas_no_coil[N_MEAS] = {0};
     double flux_pls[N_GRID], flux_vessel[N_GRID];
     double lcfs_flux, axis_flux, axis_r, axis_z;


### PR DESCRIPTION
The final elements of `meas_no_coil`, corresponding to regularisation terms, were previously uninitialized. This could result in undefined behaviour.

This change explicitly initializes `meas_no_coil` to all zeros, ensuring that the regularisation constraints are properly set to zero unless intentionally assigned later.