### PR TITLE
Changes to rtgsfit_vs_gsfit test: added lcfs_err_code and increased ivc_eigs atol

### DIFF
--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
@@ -95,6 +95,7 @@ def replay_rtgsfit(cfg: dict):
     lcfs_n = np.array([0], dtype=np.int32)
     flux_boundary = np.array([0.0], dtype=np.float64)
     plasma_current = np.array([0.0], dtype=np.float64)
+    lcfs_err_code = np.array([0], dtype=np.int32)
 
     output_dict = {"meas_pcs" : np.zeros((cfg["n_iters"] + 1, n_meas_pcs), dtype=np.float64),
                    "coil_curr" : np.zeros((cfg["n_iters"] + 1, n_coil), dtype=np.float64),
@@ -107,7 +108,8 @@ def replay_rtgsfit(cfg: dict):
                    "lcfs_n" : np.zeros((cfg["n_iters"] + 1, 1), dtype=np.int32),
                    "coef" : np.zeros((cfg["n_iters"] + 1, n_coef), dtype=np.float64),
                    "flux_boundary" : np.zeros((cfg["n_iters"] + 1, 1), dtype=np.float64),
-                   "plasma_current" : np.zeros((cfg["n_iters"] + 1, 1), dtype=np.float64)}
+                   "plasma_current" : np.zeros((cfg["n_iters"] + 1, 1), dtype=np.float64),
+                   "lcfs_err_code" : np.zeros((cfg["n_iters"] + 1, 1), dtype=np.int32)}
     output_dict["meas_pcs"][0, :] = meas_pcs
     output_dict["coil_curr"][0, :] = coil_curr
     output_dict["flux_norm"][0, :] = flux_norm
@@ -120,6 +122,7 @@ def replay_rtgsfit(cfg: dict):
     output_dict["coef"][0, :] = coef
     output_dict["flux_boundary"][0, :] = flux_boundary
     output_dict["plasma_current"][0, :] = plasma_current
+    output_dict["lcfs_err_code"][0, :] = lcfs_err_code
 
     for i_iter in range(cfg["n_iters"]):
 
@@ -139,7 +142,8 @@ def replay_rtgsfit(cfg: dict):
             lcfs_n.ctypes.data_as(ctypes.POINTER(ctypes.c_int)),
             coef.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             flux_boundary.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
-            plasma_current.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
+            plasma_current.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
+            lcfs_err_code.ctypes.data_as(ctypes.POINTER(ctypes.c_int32))
         )
 
         print("Iteration:", i_iter + 1)
@@ -156,6 +160,7 @@ def replay_rtgsfit(cfg: dict):
         output_dict["coef"][i_iter + 1, :] = coef
         output_dict["flux_boundary"][i_iter + 1, :] = flux_boundary
         output_dict["plasma_current"][i_iter + 1, :] = plasma_current
+        output_dict["lcfs_err_code"][i_iter + 1, :] = lcfs_err_code
 
     # Save output_dict to a file
     np.save(cfg["rtgsfit_output_dict_path"], output_dict, allow_pickle=True)

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
@@ -127,7 +127,7 @@ def replay_rtgsfit(cfg: dict):
         coil_curr_copy = coil_curr.copy()
 
         # Call the rtgsfit function
-        result = rtgsfit_lib.rtgsfit(
+        rtgsfit_lib.rtgsfit(
             meas_pcs_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             coil_curr_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             flux_norm.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
@@ -143,7 +143,6 @@ def replay_rtgsfit(cfg: dict):
         )
 
         print("Iteration:", i_iter + 1)
-        print("Result:", result)
 
         output_dict["meas_pcs"][i_iter + 1, :] = meas_pcs
         output_dict["coil_curr"][i_iter + 1, :] = coil_curr

--- a/tests/rtgsfit_vs_gsfit/tests/test_integration_rtgsfit_vs_gsfit.py
+++ b/tests/rtgsfit_vs_gsfit/tests/test_integration_rtgsfit_vs_gsfit.py
@@ -288,7 +288,7 @@ def test_rtgsfit_vs_gsfit_consistency(pulse_num, time):
         "psi": {"rtol": 1e-3, "atol": 5e-3},
         "psi_meas": {"rtol_meas": 5e-2, "atol_meas": 5e-2, "rtol_pred": 1e-3, "atol_pred": 1e-3},
         "bp_meas": {"rtol_meas": 5e-2, "atol_meas": 5e-2, "rtol_pred": 1e-3, "atol_pred": 1e-3},
-        "ivc_eigs": {"rtol": 1e-3, "atol": 2.8},
+        "ivc_eigs": {"rtol": 1e-3, "atol": 3.0},
         "ovc_current": {"rtol": 2e-2, "atol": 1e-2},
         "rog_meas": {"rtol_meas": 5e-2, "atol_meas": 5e2, "rtol_pred": 5e-2, "atol_pred": 1e1},
         "regression": {"rtol": 1e-8, "atol": 1e-8}


### PR DESCRIPTION
- Added lcfs_err_code to the RT-GSFit replay script so that it is now saved in the output dictionary for each iteration.

- Increased the maximum atol for ivc_eigs in the rtgsfit_vs_gsfit test from 2.8 to 3.0.

- These changes only affect the rtgsfit_vs_gsfit test routines.