### PR TITLE
setting default vscode indentation to 2 spaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,9 +57,6 @@ src/constants.c
 tests/c_*.py
 **/__pycache__
 
-# Editor files
-.vscode/
-
 # Binary data files
 *.nc
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "[c]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false
+  },
+  "[cpp]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false
+  }
+}


### PR DESCRIPTION
`"editor.tabSize": 2` → The number of spaces a tab is equal to.
`"editor.insertSpaces": true` → Use spaces not tabs.
`"editor.detectIndentation": false` → don't automatically detected the number of tabs based on file content.