### PR TITLE
Check if `lcfs_n` exceeds `N_LCFS_MAX` and if `lcfs_flux` equals `axis_flux`

### DIFF
--- a/src/find_x_point.c
+++ b/src/find_x_point.c
@@ -324,13 +324,14 @@ double lin_intrp(
   return flux_at_null;
 }
 
-void find_lcfs_rz(
+int32_t find_lcfs_rz(
     double *flux,
     double flux_lcfs,
     double *lcfs_r,
     double *lcfs_z,
     int32_t *lcfs_n) {
   double flux_offset[N_GRID];
+  int32_t error = 0;
 
   *lcfs_n = 0;
 
@@ -381,6 +382,11 @@ void find_lcfs_rz(
           }
         }
       }
+      if (*lcfs_n >= N_LCFS_MAX) {
+        // Stop if we exceed maximum number of LCFS points
+        error |= ERR_LCFS_N;
+        return error;
+      }
     }
   }
 
@@ -405,9 +411,11 @@ void find_lcfs_rz(
       (*lcfs_n)++;
     }
   }
+
+  return error;
 }
 
-int inside_lcfs(
+int32_t inside_lcfs(
     double r_opt,
     double z_opt,
     double *lcfs_r,

--- a/src/find_x_point.c
+++ b/src/find_x_point.c
@@ -18,12 +18,13 @@
 #define N_Z_TIMES_2 (N_Z * 2 - 1)
 #define MIN(aa,bb) ((aa)<=(bb)?(aa):(bb))
 #define MAX(aa,bb) ((aa)>=(bb)?(aa):(bb))
-#define ERR_MID_BDRY 0b000001 // 1
-#define ERR_COL_START 0b000010 // 2
-#define ERR_COL_END 0b000100 // 4
-#define ERR_COL_START_END 0b001000 // 8
-#define ERR_VERT_BDRY 0b010000 // 16
-#define ERR_MASK_INDEX 0b100000 // 32
+#define ERR_MID_BDRY 0b0000001 // 1
+#define ERR_COL_START 0b0000010 // 2
+#define ERR_COL_END 0b0000100 // 4
+#define ERR_COL_START_END 0b0001000 // 8
+#define ERR_VERT_BDRY 0b0010000 // 16
+#define ERR_MASK_INDEX 0b0100000 // 32
+#define ERR_LCFS_N 0b1000000 // 64
 
 /// Find crossings along the edges of a patch.
 /// 
@@ -419,6 +420,11 @@ int inside_lcfs(
   double z_tmp[N_Z_TIMES_2];
 
   memset(mask, 0, N_GRID * sizeof(int));
+
+  if (lcfs_n > N_LCFS_MAX) {
+    error |= ERR_LCFS_N;
+    return error;
+  }
 
   // Find the z grid point closest to the o-point (magnetic axis)
   double z_nearest = round((z_opt - Z_VEC[0]) / DZ) * DZ + Z_VEC[0];

--- a/src/find_x_point.c
+++ b/src/find_x_point.c
@@ -18,13 +18,14 @@
 #define N_Z_TIMES_2 (N_Z * 2 - 1)
 #define MIN(aa,bb) ((aa)<=(bb)?(aa):(bb))
 #define MAX(aa,bb) ((aa)>=(bb)?(aa):(bb))
-#define ERR_MID_BDRY 0b0000001 // 1
-#define ERR_COL_START 0b0000010 // 2
-#define ERR_COL_END 0b0000100 // 4
-#define ERR_COL_START_END 0b0001000 // 8
-#define ERR_VERT_BDRY 0b0010000 // 16
-#define ERR_MASK_INDEX 0b0100000 // 32
-#define ERR_LCFS_N 0b1000000 // 64
+#define ERR_MID_BDRY 1 // 0b00000001
+#define ERR_COL_START 2 // 0b00000010
+#define ERR_COL_END 4 // 0b00000100
+#define ERR_COL_START_END 8 // 0b00001000
+#define ERR_VERT_BDRY 16 // 0b00010000
+#define ERR_MASK_INDEX 32 // 0b00100000
+#define ERR_LCFS_N 64 // 0b01000000
+#define ERR_AX_EQ_BDRY 128 // 0b10000000
 
 /// Find crossings along the edges of a patch.
 /// 

--- a/src/find_x_point.h
+++ b/src/find_x_point.h
@@ -14,11 +14,11 @@ void find_null_in_gradient(double *psi,
         double *xpt_r, double *xpt_z, double *xpt_psi, int32_t *i_xpt);
 
 
-void find_lcfs_rz(double *psi, double psi_lcfs,
+int32_t find_lcfs_rz(double *psi, double psi_lcfs,
         double *r_lcfs, double *z_lcfs, int32_t *n_lcfs);
 
 
-int inside_lcfs(double r_opt, double z_opt, double *r_lcfs, 
+int32_t inside_lcfs(double r_opt, double z_opt, double *r_lcfs, 
         double *z_lcfs, int32_t n_lcfs, int32_t *mask);
 
 

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -402,6 +402,14 @@ void rtgsfit(
         }
     }
 
+    if (fabs(lcfs_flux - axis_flux) < THRESH)
+    {
+        // Check the boundary flux value isn't equal to the axis flux value
+        *lcfs_err_code = 128; // ERR_AX_EQ_BDRY
+        *lcfs_n = 0;
+        return;
+    }
+
     // extract LCFS
     find_lcfs_rz(flux_total, lcfs_flux, lcfs_r, lcfs_z, lcfs_n);
 

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -402,23 +402,25 @@ void rtgsfit(
         }
     }
 
-    if (fabs(lcfs_flux - axis_flux) < THRESH)
-    {
-        // Check the boundary flux value isn't equal to the axis flux value
-        *lcfs_err_code = 128; // ERR_AX_EQ_BDRY
-        *lcfs_n = 0;
-        return;
-    }
-
     // extract LCFS
-    find_lcfs_rz(flux_total, lcfs_flux, lcfs_r, lcfs_z, lcfs_n);
+    *lcfs_err_code = 0;
+    *lcfs_err_code |= find_lcfs_rz(flux_total, lcfs_flux, lcfs_r, lcfs_z, lcfs_n);
 
     // extract inside of LCFS
     // BUXTON: we think this might have an error??????
-    *lcfs_err_code = inside_lcfs(axis_r, axis_z, lcfs_r, lcfs_z, *lcfs_n, mask);
+    *lcfs_err_code |= inside_lcfs(axis_r, axis_z, lcfs_r, lcfs_z, *lcfs_n, mask);
 
     // normalise total psi
-    normalise_flux(flux_total, lcfs_flux, axis_flux, mask, flux_norm);
+    if (fabs(lcfs_flux - axis_flux) < THRESH)
+    {
+        // Check the boundary flux value isn't equal to the axis flux value
+        // To prevent division by zero
+        *lcfs_err_code |= 128; // ERR_AX_EQ_BDRY
+    }
+    else
+    {
+        normalise_flux(flux_total, lcfs_flux, axis_flux, mask, flux_norm);
+    }
 
     // store axis_r, axis_z and axis_flux in the meas_pcs array
     // meas_pcs[0] = axis_r;


### PR DESCRIPTION
  - Added new error codes for `lcfs_err_code`, namely:
    - `ERR_LCFS_N` which is flagged if `lcfs_n` exceeds `N_LCFS_MAX`.
    - `ERR_AX_EQ_BDRY` which is flagged if `|lcfs_flux - axis_flux| < THRESH`.
 - We check `ERR_AX_EQ_BDRY` to ensure we don't divide by zero in `normalise_flux()`.
 - We check `lcfs_n` in `find_lcfs_rz()` to prevent segmentation faults.