### PR TITLE
Now calculating `RBND` and `ZBND` in `py-files/write_data_to_mdsplus.py`

### DIFF
--- a/py-files/write_data_to_mdsplus.py
+++ b/py-files/write_data_to_mdsplus.py
@@ -14,8 +14,6 @@ def write_data_to_mdsplus(
     pulseNo: int,
     run_name: str = "RUN01",
     run_description: str = "Standard run with default settings",
-    settings_path: str = "default",
-    write_to_mds: bool = True,
     pulseNo_write: int | None = None,
     pulse_num_preshot: int = 99_000_230,
     run_name_preshot: str = "RUN08",
@@ -23,13 +21,6 @@ def write_data_to_mdsplus(
 ) -> None:
     """
     Write RT-GSFit results to MDSplus
-
-    :param pulseNo: pulse number
-    :param run_name: run_name to save to MDSplus
-    :param run_description: help string for MDSplus Tree
-    :param settings_path: location where code inputs are stored
-    :param write_to_mds: flag to turn on / off writing to MDSplus
-    :param pulseNo_write: pulse number in which data is to be written, if different from the current pulse
 
     :return: None
     """

--- a/py-files/write_data_to_mdsplus.py
+++ b/py-files/write_data_to_mdsplus.py
@@ -4,6 +4,7 @@ import sys
 import numpy as np
 import standard_utility as util  # type: ignore
 from diagnostics_analysis_base import NestedDict
+import matplotlib.pyplot as plt
 import mdsthin
 from netCDF4 import Dataset
 
@@ -113,10 +114,10 @@ def write_data_to_mdsplus(
     results["TIME"] = time
     results["TWO_D"]["MASK"] = mask
     results["GLOBAL"]["CHIT"] = chi_sq_err
-    results["P_BOUNDARY"]["NBND"] = lcfs_n
+    # results["P_BOUNDARY"]["NBND"] = lcfs_n
     results["TWO_D"]["PSI"] = flux_total
-    results["P_BOUNDARY"]["RBND"] = lcfs_r
-    results["P_BOUNDARY"]["ZBND"] = lcfs_z
+    # results["P_BOUNDARY"]["RBND"] = lcfs_r
+    # results["P_BOUNDARY"]["ZBND"] = lcfs_z
     results["GLOBAL"]["PSI_B"] = flux_boundary
     results["GLOBAL"]["IP"] = plasma_current
     results["GLOBAL"]["LCFS_ERR"] = lcfs_err_code
@@ -186,6 +187,36 @@ def write_data_to_mdsplus(
     results['GLOBAL']['PSI_A'] = mag_axis_flux
     results['GLOBAL']['RCUR'] = r_cur_centroid
     results['GLOBAL']['ZCUR'] = z_cur_centroid
+    
+    # Get RBND, ZBND, NBND
+    for i_time in range(len(time)):
+        mask_dilated = np.copy(mask[i_time])
+        for i in range(1, mask_dilated.shape[0] - 1):
+            for j in range(1, mask_dilated.shape[1] - 1):
+                if mask[i_time][i, j] == 1:
+                    mask_dilated[i-2:i+2, j-2:j+2] = 1
+        flux_total_masked = flux_total[i_time].copy()
+        flux_total_masked[mask_dilated != 1] = np.nan
+        fig, ax = plt.subplots(figsize=(8, 6))
+        cs = ax.contour(
+            r,
+            z,
+            flux_total_masked,
+            levels=[flux_boundary[i_time]]
+        )
+        rbnd_contour = cs.allsegs[0][0][:, 0]
+        zbnd_contour = cs.allsegs[0][0][:, 1]
+        lcfs_n = len(rbnd_contour)
+        if i_time % 100 == 0:
+            print(f"Time index {i_time} / {len(time)}")
+        lcfs_r[i_time, :lcfs_n] = rbnd_contour[:lcfs_n]
+        lcfs_r[i_time, lcfs_n:] = np.nan
+        lcfs_z[i_time, :lcfs_n] = zbnd_contour[:lcfs_n]
+        lcfs_z[i_time, lcfs_n:] = np.nan
+        results["P_BOUNDARY"]["RBND"] = lcfs_r
+        results["P_BOUNDARY"]["ZBND"] = lcfs_z
+        results["P_BOUNDARY"]["NBND"] = lcfs_n
+        plt.close(fig)
 
     util.create_script_nodes(
         script_name="RTGSFIT",

--- a/py-files/write_data_to_mdsplus.py
+++ b/py-files/write_data_to_mdsplus.py
@@ -7,6 +7,7 @@ from diagnostics_analysis_base import NestedDict
 import matplotlib.pyplot as plt
 import mdsthin
 from netCDF4 import Dataset
+from scipy.ndimage import binary_dilation
 
 
 def write_data_to_mdsplus(
@@ -189,15 +190,18 @@ def write_data_to_mdsplus(
     results['GLOBAL']['ZCUR'] = z_cur_centroid
     
     # Get RBND, ZBND, NBND
+    struct = np.ones((5,5), dtype=bool)
+    ax = plt.subplot()
     for i_time in range(len(time)):
-        mask_dilated = np.copy(mask[i_time])
-        for i in range(1, mask_dilated.shape[0] - 1):
-            for j in range(1, mask_dilated.shape[1] - 1):
-                if mask[i_time][i, j] == 1:
-                    mask_dilated[i-2:i+2, j-2:j+2] = 1
+        
+        if i_time % 100 == 0:
+            print(f"Time index {i_time} / {len(time)}")
+        
+        # Dilate the mask to ensure LCFS is included, but not too much beyond that
+        mask_dilated = binary_dilation(mask[i_time].astype(bool), structure=struct)
         flux_total_masked = flux_total[i_time].copy()
-        flux_total_masked[mask_dilated != 1] = np.nan
-        fig, ax = plt.subplots(figsize=(8, 6))
+        flux_total_masked[~mask_dilated] = np.nan
+
         cs = ax.contour(
             r,
             z,
@@ -206,17 +210,20 @@ def write_data_to_mdsplus(
         )
         rbnd_contour = cs.allsegs[0][0][:, 0]
         zbnd_contour = cs.allsegs[0][0][:, 1]
-        lcfs_n = len(rbnd_contour)
-        if i_time % 100 == 0:
-            print(f"Time index {i_time} / {len(time)}")
-        lcfs_r[i_time, :lcfs_n] = rbnd_contour[:lcfs_n]
-        lcfs_r[i_time, lcfs_n:] = np.nan
-        lcfs_z[i_time, :lcfs_n] = zbnd_contour[:lcfs_n]
-        lcfs_z[i_time, lcfs_n:] = np.nan
-        results["P_BOUNDARY"]["RBND"] = lcfs_r
-        results["P_BOUNDARY"]["ZBND"] = lcfs_z
-        results["P_BOUNDARY"]["NBND"] = lcfs_n
-        plt.close(fig)
+        nbnd_contour = len(rbnd_contour)
+
+        lcfs_n[i_time] = nbnd_contour
+        lcfs_r[i_time, :nbnd_contour] = rbnd_contour
+        lcfs_r[i_time, nbnd_contour:] = np.nan
+        lcfs_z[i_time, :nbnd_contour] = zbnd_contour
+        lcfs_z[i_time, nbnd_contour:] = np.nan
+        
+        for coll in list(ax.collections):
+            coll.remove()
+    plt.close()
+    results["P_BOUNDARY"]["RBND"] = lcfs_r
+    results["P_BOUNDARY"]["ZBND"] = lcfs_z
+    results["P_BOUNDARY"]["NBND"] = lcfs_n
 
     util.create_script_nodes(
         script_name="RTGSFIT",


### PR DESCRIPTION
## ⚠️ Warning

This version requires the `matplotlib` and `scipy` packages to be installed on **scatha3** (I used matplotlib 3.10.6 and scipy 1.16.2 for testing).  
The changes significantly slow down the `write_data_to_mdsplus.py` script, runtime increases from about **6 seconds to ~16 seconds**.

## Overview

Calculate **RBND** and **ZBND** using the `matplotlib` contour routine.

## Matplotlib vs scikit-image

It might be possible to speed this up using skimage.measure.find_contours, but I'm much more familiar with Matplotlib. Also, Matplotlib conveniently allows us to set all values outside the mask to NaN, so we don't have to worry about contours forming outside the masked region.
