### PR TITLE
Updated installation of `rtgsfit_vs_gsfit` sub-repo

### DIFF
--- a/tests/rtgsfit_verify_analytic/pyproject.toml
+++ b/tests/rtgsfit_verify_analytic/pyproject.toml
@@ -26,7 +26,6 @@ maintainers = [
 
 description = "This repository sets up and runs analytic verification tests for RTGSFIT. Input data based on a known analytic solution to the Grad-Shafranov equation. Runs RTGSFIT and checks that the numerical solution converges to the analytic as the number of iterations increases."
 readme = "README.md"
-license = { text = "GNU GENERAL PUBLIC LICENSE" }
 keywords = ["Grad", "Shafranov"]
 classifiers = [
   "Programming Language :: Python"

--- a/tests/rtgsfit_vs_gsfit/README.md
+++ b/tests/rtgsfit_vs_gsfit/README.md
@@ -5,10 +5,18 @@ It provides automated tests to verify that results from `rtgsfit` are consistent
 
 ## Installation
 
+We assume RT-GSFit is stored in `~/GitHub/rtgsfit`.
+
 ```bash
 uv venv --python 3.13
 source .venv/bin/activate
-uv pip install --reinstall -e .
+cd ~/GitHub
+git clone https://github.com/tokamak-energy/gsfit
+cd gsfit
+uv pip install -e .
+cd ~/GitHub/rtgsfit
+uv pip install -e .
+# uv pip install --reinstall -e .
 uv pip install /home/alex.prokopyszyn/my_mdsplus/python/MDSplus/.
 uv pip install "numpy<2"
 ```
@@ -70,7 +78,10 @@ uv pip install "numpy<2"
 
 To run the tests use 
 ```
+pytest -s tests
+```
+<!-- ```
 pytest -n 6 tests
 ```
 to use 6 threads. We use 6 threads as this matches the number of elements in defined in the
-`test_cases` list in `tests/test_integration_rtgsfit_vs_gsfit.py`.
+`test_cases` list in `tests/test_integration_rtgsfit_vs_gsfit.py`. -->

--- a/tests/rtgsfit_vs_gsfit/pyproject.toml
+++ b/tests/rtgsfit_vs_gsfit/pyproject.toml
@@ -26,7 +26,6 @@ maintainers = [
 
 description = "This repository sets up and runs both GSFIT and RTGSFIT. It uses MDSPlus data only available on Tokamak Energy's network."
 readme = "README.md"
-license = { text = "GNU GENERAL PUBLIC LICENSE" }
 keywords = ["Grad", "Shafranov"]
 classifiers = [
   "Programming Language :: Python :: 3"

--- a/tests/rtgsfit_vs_gsfit/pyproject.toml
+++ b/tests/rtgsfit_vs_gsfit/pyproject.toml
@@ -6,49 +6,14 @@ build-backend = "setuptools.build_meta"
 name = "rtgsfit_vs_gsfit"
 version = "2025.0.0"
 dependencies = [
-  "numpy==1.26.4",
-  "matplotlib==3.10.6",
-  "scipy==1.16.2",
-  "ipython>=8.20.0",
-  "jupyter-client>=8.6.0",
-  "psutil>=5.9.0",
-  "pytest==8.4.2",
-  "pytest-xdist==3.8.0",
-  "pyzmq>=25.1.0",
-
-  # GSFIT stack
-  "gsfit @ git+https://github.com/tokamak-energy/gsfit.git@main",
-  "f90nml==1.4.5",
-  "setuptools-git-versioning==2.1.0",
-  "toml==0.10.2",
-
-  # ST40 Database stack
-  "st40-database==0.0.62+git.c8a2a4cb",
-  "dash==3.2.0",
-  "flask==3.1.2",
-  "flexcache==0.3",
-  "flexparser==0.4",
-  "mdsthin==1.6.1",
-  "mysql-connector-python==9.4.0",
-  "narwhals==2.6.0",
-  "natsort==8.4.0",
-  "pandas==2.3.3",
-  "pint==0.25",
-  "pint-xarray==0.6.0",
-  "plotly==6.3.1",
-  "requests==2.32.5",
-  "shapely==2.1.2",
-  "xarray==2025.9.1",
-
-  # standard-utility and tooling
-  "standard-utility==0.3.131+git.fbf2a9e0",
-  "coverage==7.10.7",
-  "filelock==3.19.1",
-  "mypy==1.18.2",
-  "mypy-extensions==1.1.0",
-  "pathspec==0.12.1",
-  "pytest-cov==7.0.0",
-  "pytest-mypy==1.0.1",
+  "numpy<2",
+  "matplotlib",
+  "scipy",
+  "ipython",
+  "jupyter-client",
+  "pytest",
+  "st40-database",
+  "standard-utility",
 ]
 requires-python = ">=3.9"
 


### PR DESCRIPTION
- No longer using `pytest -n 6 tests` because running tests over multiple processors was unreliable. Tests now run in serial.  
- No longer installing GSFit via `pyproject.toml` with  
```toml
  "gsfit @ git+https://github.com/tokamak-energy/gsfit.git@main"
```
Instead, we now clone and install GSFit locally, which is more reliable.