### PR TITLE
Add optional timing to RT-GSFit

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,58 +1,131 @@
-# Check if FILENAME is defined as a command line argument
+# --------------------------------------------------
+# Required runtime parameters
+# --------------------------------------------------
 ifndef SHOT
-	ifndef RUN_NAME
-		ifneq ($(MAKECMDGOALS),clean)
-		$(error SHOT and RUN_NAME are not defined. Please provide values using 'make SHOT=<integer> RUN_NAME=<string>')
-		endif
-	endif
+  ifndef RUN_NAME
+    ifneq ($(MAKECMDGOALS),clean)
+      $(error SHOT and RUN_NAME are not defined. Please provide values using \
+              'make SHOT=<integer> RUN_NAME=<string>')
+    endif
+  endif
 endif
 
+# --------------------------------------------------
+# Compiler
+# --------------------------------------------------
 CC = gcc
+
+# --------------------------------------------------
+# Build mode
+# --------------------------------------------------
 ifndef DEBUG
-	DEBUG = 0
+  DEBUG = 0
 endif
-# print the value of DEBUG
+
+# --------------------------------------------------
+# Timing (off by default)
+# --------------------------------------------------
+ifndef TIMING
+  TIMING = 0
+endif
+
 $(info DEBUG is set to $(DEBUG))
+$(info TIMING is set to $(TIMING))
 
+# --------------------------------------------------
+# Common flags (good for perf)
+# --------------------------------------------------
+COMMON_CFLAGS = \
+  -fPIC \
+  -Wall \
+  -Warray-bounds \
+  -std=gnu11 \
+  -g \
+  -fno-omit-frame-pointer \
+  -pthread
+
+COMMON_LDFLAGS = -shared -pthread
+
+# --------------------------------------------------
+# Mode-specific flags
+# --------------------------------------------------
 ifeq ($(DEBUG), 1)
-	CFLAGS = -fPIC -Wall -Warray-bounds -pg -std=gnu11 -Ofast -pthread -g3 -O0 -DDEBUG
-	LDFLAGS = -pg -shared -g3
+  # DEBUG + gprof (instrumented, slow)
+  CFLAGS  = $(COMMON_CFLAGS) -O0 -g -pg -DDEBUG
+  LDFLAGS = -shared -g -pg
 else
-	CFLAGS = -fPIC -Wall -Warray-bounds -std=gnu11 -march=native -Ofast -funroll-loops -frename-registers -flto
-	LDFLAGS = -shared -Wl,-Ofast -pthread
+  # RELEASE + perf (real performance)
+  CFLAGS  = $(COMMON_CFLAGS) -O3 -march=native \
+            -g -fno-omit-frame-pointer
+  LDFLAGS = -shared -g
 endif
 
-OBJS = constants.o solve_tria.o gradient.o poisson_solver.o find_x_point.o rtgsfit.o
-LIB = ../lib
-SHARED = $(patsubst %.o,$(LIB)/lib%.so,$(OBJS))
+# --------------------------------------------------
+# Optional runtime timing
+# --------------------------------------------------
+ifeq ($(TIMING), 1)
+  CFLAGS += -DENABLE_RT_TIMING
+endif
+
+# --------------------------------------------------
+# Objects and libraries
+# --------------------------------------------------
+OBJS = \
+  constants.o \
+  solve_tria.o \
+  gradient.o \
+  poisson_solver.o \
+  find_x_point.o \
+  rtgsfit.o
+
+LIB     = ../lib
+SHARED  = $(patsubst %.o,$(LIB)/lib%.so,$(OBJS))
+
+# --------------------------------------------------
+# Default target
+# --------------------------------------------------
 all: constants.c $(SHARED)
 
+# --------------------------------------------------
+# Shared libraries
+# --------------------------------------------------
 $(LIB)/libfind_x_point.so: find_x_point.o gradient.o constants.o
 	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ -lm
 
 $(LIB)/libpoisson_solver.so: poisson_solver.o gradient.o solve_tria.o constants.o
-	$(CC) $(LDFLAGS) -Wl,-soname,-Wl,--no-undefined -o $@ $^ -lopenblas
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ -lopenblas
 
-$(LIB)/libsolve_tria.so: solve_tria.o  constants.o
-	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^
+$(LIB)/libsolve_tria.so: solve_tria.o constants.o
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ 
 
-$(LIB)/libgradient.so: gradient.o  constants.o
-	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^
+$(LIB)/libgradient.so: gradient.o constants.o
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ 
 
 $(LIB)/libconstants.so: constants.o
-	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ 
 
-$(LIB)/librtgsfit.so: rtgsfit.o gradient.o constants.o poisson_solver.o find_x_point.o solve_tria.o
-	$(CC) $(LDFLAGS) $(CFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ -lm -lopenblas
+$(LIB)/librtgsfit.so: \
+  rtgsfit.o gradient.o constants.o poisson_solver.o find_x_point.o solve_tria.o
+	$(CC) $(LDFLAGS) -Wl,-soname,$@ -Wl,--no-undefined -o $@ $^ -lm -lopenblas
 
+# --------------------------------------------------
+# Object compilation
+# --------------------------------------------------
 $(OBJS): %.o : %.c
 	$(CC) $(CFLAGS) -I/usr/include/openblas -c $< -o $@
 
+# Explicit rule kept (optional but fine)
 rtgsfit.o: rtgsfit.c
-	$(CC) $(CFLAGS) -I/usr/include/openblas -o $@  -c $< 
+	$(CC) $(CFLAGS) -I/usr/include/openblas -c $< -o $@
 
+# --------------------------------------------------
+# Generated source
+# --------------------------------------------------
 constants.c: constants.h
 	python ../utility/mdsplus_const_to_file.py SHOT=$(SHOT) RUN_NAME=$(RUN_NAME)
 
+# --------------------------------------------------
+# Cleanup
+# --------------------------------------------------
 clean:
-	rm -f $(SHARED) $(OBJS)  constants.c *.pyc
+	rm -f $(SHARED) $(OBJS) constants.c *.pyc

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -17,11 +17,12 @@
 
 #ifdef ENABLE_RT_TIMING
 
-static inline uint64_t now_ns(void)
+static inline uint64_t thread_cpu_ns(void)
 {
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
-    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+    int ret = clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts);
+    assert(ret == 0);
+    return (uint64_t)ts.tv_sec * 1000000000ull + ts.tv_nsec;
 }
 
 enum {
@@ -48,8 +49,8 @@ enum {
 static uint64_t timing_acc[T_NTIMERS];
 static uint64_t timing_t0;
 
-#define TSTART()        do { timing_t0 = now_ns(); } while (0)
-#define TACC(idx)       do { timing_acc[(idx)] += (now_ns() - timing_t0); } while (0)
+#define TSTART()        do { timing_t0 = thread_cpu_ns(); } while (0)
+#define TACC(idx)       do { timing_acc[(idx)] += (thread_cpu_ns() - timing_t0); } while (0)
 
 void rtgsfit_timing_reset(void)
 {
@@ -294,7 +295,7 @@ void rtgsfit(
         )
 {
 #ifdef ENABLE_RT_TIMING
-    uint64_t t_total_0 = now_ns();
+    uint64_t t_total_0 = thread_cpu_ns();
 #endif // ENABLE_RT_TIMING
 
     assert(n_meas_model == N_MEAS);
@@ -572,6 +573,6 @@ void rtgsfit(
     *flux_boundary = lcfs_flux;
 
 #ifdef ENABLE_RT_TIMING
-    timing_acc[T_TOTAL] += (now_ns() - t_total_0);
+    timing_acc[T_TOTAL] += (thread_cpu_ns() - t_total_0);
 #endif
 }

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -11,13 +11,86 @@
 #include <stdint.h>
 #include <string.h>
 #include <assert.h>
+#include <time.h>
 
-#define N_MEAS_NO_REG N_BP_PROBES + N_FLUX_LOOPS + N_ROGOWSKI_COILS
+#define N_MEAS_NO_REG (N_BP_PROBES + N_FLUX_LOOPS + N_ROGOWSKI_COILS)
 
-int32_t max_idx(
-        int32_t n_arr,
-        double* arr
-        )
+#ifdef ENABLE_RT_TIMING
+
+static inline uint64_t now_ns(void)
+{
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ull + (uint64_t)ts.tv_nsec;
+}
+
+enum {
+    T_MEAS_PREP = 0,
+    T_BASIS,
+    T_MEAS_MATRIX,
+    T_WEIGHTING,
+    T_LS_FIT,
+    T_SOURCE,
+    T_MODEL_MEAS,
+    T_CHI2,
+    T_POISSON,
+    T_COIL_FLUX,
+    T_VESSEL_FLUX,
+    T_NULLS_AND_AXIS,
+    T_LIMITER,
+    T_LCFS,
+    T_INSIDE,
+    T_NORMALISE,
+    T_TOTAL,
+    T_NTIMERS
+};
+
+static uint64_t timing_acc[T_NTIMERS];
+static uint64_t timing_t0;
+
+#define TSTART()        do { timing_t0 = now_ns(); } while (0)
+#define TACC(idx)       do { timing_acc[(idx)] += (now_ns() - timing_t0); } while (0)
+
+void rtgsfit_timing_reset(void)
+{
+    for (int i = 0; i < T_NTIMERS; i++) timing_acc[i] = 0;
+}
+
+void rtgsfit_timing_dump(void)
+{
+    static const char *names[T_NTIMERS] = {
+        "meas_prep",
+        "basis",
+        "meas_matrix",
+        "weighting",
+        "ls_fit",
+        "source",
+        "model_meas",
+        "chi2",
+        "poisson",
+        "coil_flux",
+        "vessel_flux",
+        "nulls_axis",
+        "limiter",
+        "lcfs",
+        "inside",
+        "normalise",
+        "total"
+    };
+
+    for (int i = 0; i < T_NTIMERS; i++) {
+        printf("%-12s : %10.3f us\n", names[i], (double)timing_acc[i] * 1e-3);
+    }
+}
+
+#else
+
+#define TSTART()        do {} while (0)
+#define TACC(idx)       do {} while (0)
+
+#endif // ENABLE_RT_TIMING
+
+int32_t max_idx(int32_t n_arr, double* arr)
 {
     int i_arr;
     int i_max = 0;
@@ -145,8 +218,6 @@ double find_flux_on_limiter_xfiltered(double flux_total[],
     for (int32_t i_limit = 0; i_limit < N_LIMIT; i_limit++)
     {
 
-        // If dot product of (R_LIM[i_limit] - xpt_r, Z_LIM[i_limit] - xpt_z) and 
-        // (r_mag_axis - xpt_r, z_mag_axis - xpt_z) is negative for any xpt, skip this limit point
         skip = 0;
         for (int32_t i_xpt = 0; i_xpt < xpt_n; i_xpt++)
         {
@@ -154,7 +225,7 @@ double find_flux_on_limiter_xfiltered(double flux_total[],
                           (LIMIT_Z[i_limit] - xpt_z[i_xpt]) * (z_mag_axis - xpt_z[i_xpt]);
             if (dot_product < 0.0)
             {
-                skip = 1; // skip this limit point
+                skip = 1;
                 break;
             }
         }
@@ -186,7 +257,6 @@ void normalise_flux(
     double inv_flux_diff;
     inv_flux_diff = 1.0/(flux_lcfs - flux_axis);
 
-    // psi norm has to be of total flux, as boundary is defined in terms of total flux !
     for (int32_t i_grid = 0; i_grid < N_GRID; i_grid++)
     {
         if (mask[i_grid] && MASK_LIM[i_grid])
@@ -224,6 +294,10 @@ void rtgsfit(
         double* z_cur_centroid  // output
         )
 {
+#ifdef ENABLE_RT_TIMING
+    uint64_t t_total_0 = now_ns();
+#endif // ENABLE_RT_TIMING
+
     assert(n_meas_model == N_MEAS);
     // N_MEAS includes the number of regularisations.
     // n_meas_no_reg is the number of measurements after the regularisations have been removed.
@@ -235,8 +309,14 @@ void rtgsfit(
     // meas_pcs contains the raw measurements from the PCS that need to be post-processed
     // using the SENSOR_REPLACEMENT_MATRIX.
     double meas[N_MEAS_NO_REG];
-    cblas_dgemv(CblasRowMajor, CblasNoTrans, N_MEAS_NO_REG, N_SENS_PCS, 1.0,
-            SENSOR_REPLACEMENT_MATRIX, N_SENS_PCS, meas_pcs, 1, 0.0, meas, 1);
+
+    TSTART();
+    cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                N_MEAS_NO_REG, N_SENS_PCS,
+                1.0, SENSOR_REPLACEMENT_MATRIX, N_SENS_PCS,
+                meas_pcs, 1,
+                0.0, meas, 1);
+    TACC(T_MEAS_PREP);
 
     // will this be done during compilation?
     double g_coef_meas_w[N_COEF * N_MEAS];
@@ -248,25 +328,37 @@ void rtgsfit(
     // and includes the regularisation elements, which can be thought of as fake Rogowski coil
     // measurements.
     double meas_no_coil[N_MEAS];
+
+    TSTART();
     rm_coil_from_meas(coil_curr, meas, meas_no_coil);
+    TACC(T_MEAS_PREP);
 
     // make basis
     // This makes the transpose of the T_{yg} matrix in eqn. (61) of the Moret et al. (2015)
     // LIUQE paper, without the Delta_R * Delta_Z factor.
     double g_pls_grid[N_PLS * N_GRID];
+
+    TSTART();
     make_basis(flux_norm, mask, g_pls_grid);
+    TACC(T_BASIS);
 
     // make meas-pls matrix
     // g_coef_meas_w = g_pls_grid * G_GRID_MEAS_WEIGHT
-    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, N_PLS, N_MEAS, N_GRID,
-            1.0, g_pls_grid, N_GRID, G_GRID_MEAS_WEIGHT, N_MEAS, 0.0,
-            g_coef_meas_w, N_MEAS);
+    TSTART();
+    cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans,
+                N_PLS, N_MEAS, N_GRID,
+                1.0, g_pls_grid, N_GRID,
+                G_GRID_MEAS_WEIGHT, N_MEAS,
+                0.0, g_coef_meas_w, N_MEAS);
+    TACC(T_MEAS_MATRIX);
 
     // form meas vectors from measurements
+    TSTART();
     for (int32_t i_meas = 0; i_meas < N_MEAS; i_meas++)
     {
         meas_no_coil[i_meas] *= WEIGHT[i_meas];
     }
+    TACC(T_WEIGHTING);
 
     double meas_no_coil_cp[N_MEAS];
     double g_coef_meas_w_orig[N_COEF * N_MEAS];
@@ -283,19 +375,22 @@ void rtgsfit(
     lapack_int rank;
     double rcond = -1.0;
     double single_vals[N_COEF];
+
+    TSTART();
     *lapack_dgelss_info = LAPACKE_dgelss(
-      LAPACK_COL_MAJOR,
-      N_MEAS,
-      N_COEF,
-      1,
-      g_coef_meas_w,
-      N_MEAS,
-      meas_no_coil_cp,
-      N_MEAS,
-      single_vals,
-      rcond,
-      &rank
+        LAPACK_COL_MAJOR,
+        N_MEAS,
+        N_COEF,
+        1,
+        g_coef_meas_w,
+        N_MEAS,
+        meas_no_coil_cp,
+        N_MEAS,
+        single_vals,
+        rcond,
+        &rank
     );
+    TACC(T_LS_FIT);
 
     // BUXTON: copy "meas_no_coil_cp" into "coef"
     memcpy(coef, meas_no_coil_cp, sizeof(double) * N_COEF);
@@ -305,8 +400,13 @@ void rtgsfit(
     // BUXTON: "source = g_pls_grid * coef"
     // BUXTON: source = plasma current on (R, Z) grid
     double source[N_GRID];
-    cblas_dgemv(CblasRowMajor, CblasTrans, N_PLS, N_GRID, 1.0, g_pls_grid,
-            N_GRID, coef, 1, 0.0, source, 1);
+
+    TSTART();
+    cblas_dgemv(CblasRowMajor, CblasTrans,
+                N_PLS, N_GRID,
+                1.0, g_pls_grid, N_GRID,
+                coef, 1,
+                0.0, source, 1);
 
     // `source` is the current density in each grid cell;
     // plasma_current = sum(source) * d_area
@@ -328,21 +428,29 @@ void rtgsfit(
         *r_cur_centroid = 0.0;
         *z_cur_centroid = 0.0;
     }
+    TACC(T_SOURCE);
 
     // modelled measurements
     // BUXTON: measurements
     // BUXTON: "meas_model = g_coef_meas_w_orig * coef"
     // double meas_model_arr[N_MEAS];
-    cblas_dgemv(CblasRowMajor, CblasTrans, N_COEF, N_MEAS, 1.0, g_coef_meas_w_orig,
-            N_MEAS, coef, 1, 0.0, meas_model, 1);
-    
+    TSTART();
+    cblas_dgemv(CblasRowMajor, CblasTrans,
+                N_COEF, N_MEAS,
+                1.0, g_coef_meas_w_orig, N_MEAS,
+                coef, 1,
+                0.0, meas_model, 1);
+    TACC(T_MODEL_MEAS);
+
     // find chi squared error between meas and model
+    TSTART();
     *chi_sq_err = 0.0;
     for (int32_t i_meas = 0; i_meas < N_MEAS_NO_REG; i_meas++)
     {
         double diff = meas_no_coil[i_meas] - meas_model[i_meas];
         *chi_sq_err += diff * diff;
     }
+    TACC(T_CHI2);
 
     // convert current to RHS of eq
     for (int32_t i_grid = 0; i_grid < N_GRID; i_grid++)
@@ -353,38 +461,45 @@ void rtgsfit(
     //  poisson solver -> psi_plasma
     // BUXTON: calculate psi_plasma
     double flux_pls[N_GRID];
-    poisson_solver(source, flux_pls);
 
-    // calculate coil psi on grid
-    // BUXTON: "flux_total = G_GRID_COIL * coil_curr"
-    cblas_dgemv(CblasRowMajor, CblasNoTrans, N_GRID, N_COIL, 1.0, G_GRID_COIL,
-            N_COIL, coil_curr, 1, 0.0, flux_total, 1);
+    TSTART();
+    poisson_solver(source, flux_pls);
+    TACC(T_POISSON);
+
+    // coil psi on grid: flux_total = G_GRID_COIL * coil_curr */
+    TSTART();
+    cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                N_GRID, N_COIL,
+                1.0, G_GRID_COIL, N_COIL,
+                coil_curr, 1,
+                0.0, flux_total, 1);
+    TACC(T_COIL_FLUX);
 
     // calculate vessel flux on grid
     if (N_VESS > 0)
     {
-
         double flux_vessel[N_GRID];
-        cblas_dgemv(CblasRowMajor, CblasNoTrans, N_GRID, N_VESS, 1.0, G_GRID_VESSEL,
-                N_VESS, &coef[N_PLS], 1, 0.0, flux_vessel, 1);
 
-        // calculate total flux = coil + plasma + vessel
+        TSTART();
+        cblas_dgemv(CblasRowMajor, CblasNoTrans,
+                    N_GRID, N_VESS,
+                    1.0, G_GRID_VESSEL, N_VESS,
+                    &coef[N_PLS], 1,
+                    0.0, flux_vessel, 1);
+
         for (int32_t i_grid = 0; i_grid < N_GRID; i_grid++)
         {
-            flux_total[i_grid] +=  flux_pls[i_grid] + flux_vessel[i_grid];
-            // BUXTON: do I need to add delta_z*d(psi)/d(psi_n)
+            flux_total[i_grid] += flux_pls[i_grid] + flux_vessel[i_grid];
         }
+        TACC(T_VESSEL_FLUX);
     }
     else
     {
-        for (int32_t i_grid=0; i_grid < N_GRID; i_grid++)
+        for (int32_t i_grid = 0; i_grid < N_GRID; i_grid++)
         {
-            flux_total[i_grid] +=  flux_pls[i_grid];
+            flux_total[i_grid] += flux_pls[i_grid];
         }
     }
-
-    // flux value on limiter
-    // lcfs_flux = find_flux_on_limiter(flux_total); // Using find_flux_on_limiter_xfiltered instead.
 
     // find x point & opt
     double xpt_r[N_XPT_MAX];
@@ -396,23 +511,31 @@ void rtgsfit(
 
     int32_t xpt_n = 0;
     int32_t opt_n = 0;
-    find_null_in_gradient_march(flux_total, opt_r, opt_z, opt_flux, &opt_n,
-            xpt_r, xpt_z, xpt_flux, &xpt_n);
 
-    // select opt
+    TSTART();
+    find_null_in_gradient_march(flux_total,
+                                opt_r, opt_z, opt_flux, &opt_n,
+                                xpt_r, xpt_z, xpt_flux, &xpt_n);
+
     int32_t i_opt = max_idx(opt_n, opt_flux);
     *mag_axis_flux = opt_flux[i_opt];
     *r_mag_axis = opt_r[i_opt];
     *z_mag_axis = opt_z[i_opt];
+    TACC(T_NULLS_AND_AXIS);
 
-    double lcfs_flux = find_flux_on_limiter_xfiltered(flux_total, xpt_r, xpt_z, xpt_n, *r_mag_axis, *z_mag_axis);
+    // limiter flux with x-point filtering
+    TSTART();
+    double lcfs_flux = find_flux_on_limiter_xfiltered(flux_total,
+                                                      xpt_r, xpt_z, xpt_n,
+                                                      *r_mag_axis, *z_mag_axis);
+    TACC(T_LIMITER);
 
     // select xpt
     if (xpt_n > 0)
     {
         int32_t i_xpt = max_idx(xpt_n, xpt_flux);
         double xpt_flux_max = xpt_flux[i_xpt];
-        xpt_flux_max = FRAC * xpt_flux_max + (1.0-FRAC)*(*mag_axis_flux);
+        xpt_flux_max = FRAC * xpt_flux_max + (1.0 - FRAC) * (*mag_axis_flux);
         if (xpt_flux_max > lcfs_flux)
         {
             lcfs_flux = xpt_flux_max;
@@ -421,24 +544,35 @@ void rtgsfit(
 
     // extract LCFS
     *lcfs_err_code = 0;
-    *lcfs_err_code |= find_lcfs_rz(flux_total, lcfs_flux, lcfs_r, lcfs_z, lcfs_n);
 
-    // extract inside of LCFS
-    // BUXTON: we think this might have an error??????
-    *lcfs_err_code |= inside_lcfs(*r_mag_axis, *z_mag_axis, lcfs_r, lcfs_z, *lcfs_n, mask);
+    TSTART();
+    *lcfs_err_code |= find_lcfs_rz(flux_total, lcfs_flux, lcfs_r, lcfs_z, lcfs_n);
+    TACC(T_LCFS);
+
+    // inside LCFS mask
+    TSTART();
+    *lcfs_err_code |= inside_lcfs(*r_mag_axis, *z_mag_axis,
+                                  lcfs_r, lcfs_z, *lcfs_n, mask);
+    TACC(T_INSIDE);
 
     // normalise total psi
     if (fabs(lcfs_flux - (*mag_axis_flux)) < THRESH)
     {
-      // Don't call normalise_flux if lcfs_flux is too close to mag_axis_flux
-      // This avoids division by a very small number.
+        // Don't call normalise_flux if lcfs_flux is too close to mag_axis_flux
+        // This avoids division by a very small number.
         *lcfs_err_code |= 128; // ERR_AX_EQ_BDRY
     }
     else
     {
+        TSTART();
         normalise_flux(flux_total, lcfs_flux, *mag_axis_flux, mask, flux_norm);
+        TACC(T_NORMALISE);
     }
 
     // Store psi_b for later
     *flux_boundary = lcfs_flux;
+
+#ifdef ENABLE_RT_TIMING
+    timing_acc[T_TOTAL] += (now_ns() - t_total_0);
+#endif
 }

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -80,7 +80,7 @@ void rtgsfit_timing_dump(void)
     };
 
     for (int i = 0; i < T_NTIMERS; i++) {
-        printf("%-12s : %10.3f us\n", names[i], (double)timing_acc[i] * 1e-3);
+        printf("%-14s : %10.3f us\n", names[i], (double)timing_acc[i] * 1e-3);
     }
 }
 

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -37,7 +37,7 @@ enum {
     T_POISSON,
     T_COIL_FLUX,
     T_VESSEL_FLUX,
-    T_NULLS_AND_AXIS,
+    T_XPTS_AND_AXIS,
     T_LIMITER,
     T_LCFS,
     T_INSIDE,
@@ -71,7 +71,7 @@ void rtgsfit_timing_dump(void)
         "poisson",
         "coil_flux",
         "vessel_flux",
-        "nulls_axis",
+        "xpts_and_axis",
         "limiter",
         "lcfs",
         "inside",
@@ -521,7 +521,7 @@ void rtgsfit(
     *mag_axis_flux = opt_flux[i_opt];
     *r_mag_axis = opt_r[i_opt];
     *z_mag_axis = opt_z[i_opt];
-    TACC(T_NULLS_AND_AXIS);
+    TACC(T_XPTS_AND_AXIS);
 
     // limiter flux with x-point filtering
     TSTART();

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -124,7 +124,6 @@ void rm_coil_from_meas(
     }
 }
 
-
 void make_basis(
         double* flux_norm,
         int* mask,

--- a/src/rtgsfit.h
+++ b/src/rtgsfit.h
@@ -15,6 +15,10 @@ void make_basis(double* psi_norm, int* mask, double* basis);
 void normalise_flux(double* flux_total, double flux_lcfs,
         double flux_axis,int* mask, double* flux_norm);
 
+#if defined(ENABLE_RT_TIMING)
+void rtgsfit_timing_reset(void);
+void rtgsfit_timing_dump(void);
+#endif
 
 void rtgsfit(double *meas_pcs, double *coil_curr, double *flux_norm, int32_t *mask,
         double *flux_total, double *chi_sq_err, double *lcfs_r, double *lcfs_z,

--- a/tests/rtgsfit_vs_gsfit/README.md
+++ b/tests/rtgsfit_vs_gsfit/README.md
@@ -14,7 +14,7 @@ cd ~/GitHub
 git clone https://github.com/tokamak-energy/gsfit
 cd gsfit
 uv pip install -e .
-cd ~/GitHub/rtgsfit
+cd ~/GitHub/rtgsfit/tests/rtgsfit_vs_gsfit
 uv pip install -e .
 # uv pip install --reinstall -e .
 uv pip install /home/alex.prokopyszyn/my_mdsplus/python/MDSplus/.

--- a/tests/rtgsfit_vs_gsfit/data/default_config.json
+++ b/tests/rtgsfit_vs_gsfit/data/default_config.json
@@ -14,6 +14,8 @@
   "z_axis0": 0.0,
   "rho_boundary0": 0.2,
 
+  "rt_timing": true,
+
   "n_iters": 10,
 
   "n_r": 33,

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
@@ -76,6 +76,12 @@ def replay_rtgsfit(cfg: dict):
         ctypes.POINTER(ctypes.c_double)   # z_cur_centroid
     ]
     rtgsfit_lib.rtgsfit.restype = None
+    
+    # Timing helpers
+    rtgsfit_lib.rtgsfit_timing_reset.argtypes = []
+    rtgsfit_lib.rtgsfit_timing_reset.restype = None
+    rtgsfit_lib.rtgsfit_timing_dump.argtypes = []
+    rtgsfit_lib.rtgsfit_timing_dump.restype = None
 
     meas_pcs = prep_meas_coil_curr.prep_meas_pcs(cfg)
     coil_curr = prep_meas_coil_curr.prep_coil_curr(cfg)
@@ -163,8 +169,8 @@ def replay_rtgsfit(cfg: dict):
 
         meas_pcs_copy = meas_pcs.copy()
         coil_curr_copy = coil_curr.copy()
-
-        # Call the rtgsfit function
+        
+        rtgsfit_lib.rtgsfit_timing_reset()
         rtgsfit_lib.rtgsfit(
             meas_pcs_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             coil_curr_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
@@ -188,7 +194,7 @@ def replay_rtgsfit(cfg: dict):
             r_cur_centroid.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             z_cur_centroid.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
         )
-
+        rtgsfit_lib.rtgsfit_timing_dump()
         print("Iteration:", i_iter + 1)
 
         output_dict["meas_pcs"][i_iter + 1, :] = meas_pcs

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/replay_rtgsfit.py
@@ -78,10 +78,11 @@ def replay_rtgsfit(cfg: dict):
     rtgsfit_lib.rtgsfit.restype = None
     
     # Timing helpers
-    rtgsfit_lib.rtgsfit_timing_reset.argtypes = []
-    rtgsfit_lib.rtgsfit_timing_reset.restype = None
-    rtgsfit_lib.rtgsfit_timing_dump.argtypes = []
-    rtgsfit_lib.rtgsfit_timing_dump.restype = None
+    if cfg.get("rt_timing", True):
+        rtgsfit_lib.rtgsfit_timing_reset.argtypes = []
+        rtgsfit_lib.rtgsfit_timing_reset.restype = None
+        rtgsfit_lib.rtgsfit_timing_dump.argtypes = []
+        rtgsfit_lib.rtgsfit_timing_dump.restype = None
 
     meas_pcs = prep_meas_coil_curr.prep_meas_pcs(cfg)
     coil_curr = prep_meas_coil_curr.prep_coil_curr(cfg)
@@ -170,7 +171,8 @@ def replay_rtgsfit(cfg: dict):
         meas_pcs_copy = meas_pcs.copy()
         coil_curr_copy = coil_curr.copy()
         
-        rtgsfit_lib.rtgsfit_timing_reset()
+        if cfg.get("rt_timing", True):
+            rtgsfit_lib.rtgsfit_timing_reset()
         rtgsfit_lib.rtgsfit(
             meas_pcs_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             coil_curr_copy.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
@@ -194,7 +196,8 @@ def replay_rtgsfit(cfg: dict):
             r_cur_centroid.ctypes.data_as(ctypes.POINTER(ctypes.c_double)),
             z_cur_centroid.ctypes.data_as(ctypes.POINTER(ctypes.c_double))
         )
-        rtgsfit_lib.rtgsfit_timing_dump()
+        if cfg.get("rt_timing", True):
+            rtgsfit_lib.rtgsfit_timing_dump()
         print("Iteration:", i_iter + 1)
 
         output_dict["meas_pcs"][i_iter + 1, :] = meas_pcs

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
@@ -188,7 +188,7 @@ def compile_rtgsfit(cfg: dict):
     # Compile RTGSFIT
     os.chdir(cfg['rtgsfit_src_path'])
     subprocess.run(
-        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=1 TIMING={int(cfg.get('rt_timing', True))}",
+        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=0 TIMING={int(cfg.get('rt_timing', True))}",
         cwd=cfg['rtgsfit_src_path'],
         check=True,
         shell=True

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
@@ -188,7 +188,7 @@ def compile_rtgsfit(cfg: dict):
     # Compile RTGSFIT
     os.chdir(cfg['rtgsfit_src_path'])
     subprocess.run(
-        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=1",
+        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=1 TIMING=1",
         cwd=cfg['rtgsfit_src_path'],
         check=True,
         shell=True

--- a/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
+++ b/tests/rtgsfit_vs_gsfit/src/rtgsfit_vs_gsfit/rtgsfit_compile_setup.py
@@ -188,7 +188,7 @@ def compile_rtgsfit(cfg: dict):
     # Compile RTGSFIT
     os.chdir(cfg['rtgsfit_src_path'])
     subprocess.run(
-        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=1 TIMING=1",
+        f"make SHOT={cfg['pulse_num_write']} RUN_NAME={cfg['run_name']} DEBUG=1 TIMING={int(cfg.get('rt_timing', True))}",
         cwd=cfg['rtgsfit_src_path'],
         check=True,
         shell=True


### PR DESCRIPTION
The goal of these changes is to make it easier to see which bits of the code are fast and which are slow, i.e. to profile the code and understand where the computational load actually is.

A `TIMING` flag has been added to the Makefile. If `TIMING=1`, then `DENABLE_RT_TIMING` is appended to `CFLAGS`. When this is enabled, `RT-GSFit` uses `clock_gettime` for timing.

The main addition is two new functions:
- `rtgsfit_timing_reset()`
- `rtgsfit_timing_dump()`

These are used to reset and dump the collected timing information respectively.

The `rtgsfit_vs_gsfit` test has been modified so that `rtgsfit_timing_dump()` is called, meaning timing information is printed as part of the test run.

Overall this is intended as a lightweight way to get some insight into where time is being spent without changing normal behaviour when timing is disabled.

EDIT: As per Filip's suggestion, we now use `CLOCK_THREAD_CPUTIME_ID` instead of `CLOCK_MONOTONIC_RAW`, since it measures per-thread CPU time and is therefore less affected by OS scheduling noise.
