### PR TITLE
Enforce 'const' qualification for input pointers

### DIFF
--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -266,7 +266,7 @@ void rtgsfit(
         int32_t *lcfs_err_code, // output
         int* lapack_dgelss_info, // output
         double *meas_model, // output
-        int32_t n_meas_model, // input
+        const int32_t n_meas_model, // input
         double* r_mag_axis, // output
         double* z_mag_axis,  // output
         double* mag_axis_flux, // output
@@ -275,7 +275,7 @@ void rtgsfit(
         double* xpt_r, // output array
         double* xpt_z, // output array
         double* xpt_flux, // output array
-        int32_t xpt_arrays_size, // input
+        const int32_t xpt_arrays_size, // input
         int32_t* xpt_n, // output integer
         int32_t* xpt_diverted // output integer
         )

--- a/src/rtgsfit.c
+++ b/src/rtgsfit.c
@@ -113,7 +113,7 @@ int32_t max_idx(int32_t n_arr, double* arr)
 }
 
 void rm_coil_from_meas(
-        double* coil_curr,
+        const double* coil_curr,
         double* meas,
         double* meas_no_coil
         )
@@ -251,8 +251,8 @@ void normalise_flux(
 }
 
 void rtgsfit(
-        double* meas_pcs, // input
-        double* coil_curr, // input
+        const double* meas_pcs, // input
+        const double* coil_curr, // input
         double* flux_norm, // input/output
         int32_t* mask, // input/output
         double* flux_total, // output

--- a/src/rtgsfit.h
+++ b/src/rtgsfit.h
@@ -5,7 +5,7 @@
 
 int max_idx(int n_arr, double *arr);
 
-void rm_coil_from_meas(double *coil_curr, double *meas, double *meas_no_coil);
+void rm_coil_from_meas(const double *coil_curr, double *meas, double *meas_no_coil);
 
 void make_basis(double *psi_norm, int *mask, double *basis);
 
@@ -17,7 +17,7 @@ void rtgsfit_timing_reset(void);
 void rtgsfit_timing_dump(void);
 #endif
 
-void rtgsfit(double *meas_pcs, double *coil_curr, double *flux_norm, int32_t *mask,
+void rtgsfit(const double *meas_pcs, const double *coil_curr, double *flux_norm, int32_t *mask,
         double *flux_total, double *chi_sq_err, double *lcfs_r, double *lcfs_z,
         int32_t *lcfs_n, double *coef, double *flux_boundary, double *plasma_current,
         int32_t *lcfs_err_code, int *lapack_dgelss_info, double *meas_model,

--- a/src/rtgsfit.h
+++ b/src/rtgsfit.h
@@ -21,8 +21,8 @@ void rtgsfit(const double *meas_pcs, const double *coil_curr, double *flux_norm,
         double *flux_total, double *chi_sq_err, double *lcfs_r, double *lcfs_z,
         int32_t *lcfs_n, double *coef, double *flux_boundary, double *plasma_current,
         int32_t *lcfs_err_code, int *lapack_dgelss_info, double *meas_model,
-        int32_t n_meas_model, double* r_mag_axis, double* z_mag_axis, double* mag_axis_flux,
+        const int32_t n_meas_model, double* r_mag_axis, double* z_mag_axis, double* mag_axis_flux,
         double* r_cur_centroid, double* z_cur_centroid, double* xpt_r, double* xpt_z,
-        double* xpt_flux, int32_t xpt_arrays_size, int32_t* xpt_n, int32_t* xpt_diverted);
+        double* xpt_flux, const int32_t xpt_arrays_size, int32_t* xpt_n, int32_t* xpt_diverted);
 
 #endif


### PR DESCRIPTION
During compilation, the following warnings were raised for `meas_pcs` and `coil_curr` - input arguments to `rtgsfit()`.

`Warning: Assigning read-only input or parameter symbol 'meas_pcs' address to non "const" qualified pointer target type is not recommended in the C Function block 'RT_Diagnostics/rtgsfit_gap/rtgsfit/C_func_rtgsfit' and may cause build failure during code generation. Occurred in line: rtgsfit(meas_pcs, coil_curr, flux_norm, mask, ... `

This is simply suggesting that since these values are inputs and read-only, that the arguments and subsequent treatment within the function should also be `const` qualified to prevent undesired modifications.

### Before
```c
rtgsfit(double *meas_pcs, double *coil_curr, ...
```

### After
```c
rtgsfit(const double *meas_pcs, const double *coil_curr, ...
```

The corresponding change was also made to `rm_coil_from_meas` for consistency.